### PR TITLE
Feature/api examples

### DIFF
--- a/examples/listing.php
+++ b/examples/listing.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Example PHP for listing MSPECS deals, using ../public-api.php
+ * 
+ * Alternative method:
+ *  - Deals are by default non-public custom post types.
+ *    Using the 'mspecs_deal_post_type' filter you can instead make them public
+ *    to utilize the standard WordPress API
+ * 
+ */
+
+if(!defined('MSPECS_PLUGIN_DIR')) {
+    echo 'MSPECS plugin not installed';
+    return;
+}
+
+// Get all deals, as a WP_Post objects
+$deals = mspecs_get_deals();
+
+if(empty($deals)){
+    echo 'No deals found, please configure plugin and sync all deals';
+    return;
+}
+
+?>
+<table>
+    <?php
+    // Loop through deals
+    foreach($deals as $deal):
+
+        // Get the deals meta data
+        $data = mspecs_get_mspecs_meta($deal);
+
+        ?>
+        <tr>
+            <?php // Output the shortId, using standard array access ?>
+            <td><?= esc_html($data['shortId']) ?></td>
+
+            <?php // Output a formatted location, using the safe array access method mspecs_get ?>
+            <td><?= esc_html(implode(', ', [mspecs_get($data, 'location.streetAddress'), mspecs_get($data, 'location.city')])) ?></td>
+
+            <?php // Output images tags using the self hosted URL provided by mspecs_get_deal_images ?>
+            <td><?= implode('', array_map(function($image){
+                return '<img src="'.esc_attr($image['thumbnailUrl']).'" />';
+            }, mspecs_get_deal_images($deal))) ?></td>
+
+            <?php // Output file download links using the self hosted URL provided by mspecs_get_deal_files ?>
+            <td><?= implode('<br>', array_map(function($file){
+                return '<a href="'.esc_url($file['url']).'" download>'.esc_html($file['title']).'</a>';
+            }, mspecs_get_deal_files($deal))) ?></td>
+        </tr>
+    <?php endforeach ?>
+</table>
+

--- a/examples/single.php
+++ b/examples/single.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Example PHP for displaying a single MSPECS deal, using ../public-api.php
+ * 
+ */
+
+if(!defined('MSPECS_PLUGIN_DIR')) {
+    echo 'MSPECS plugin not installed';
+    return;
+}
+
+// Get an example deal ID, replace this with the ID you want to display
+$deal_id = get_dummy_deal_id();
+
+if(!$deal_id){
+    echo 'No deals found, please configure plugin and sync all deals';
+    return;
+}
+
+// Get the deal with the given ID, as a WP_Post object
+$deal = mspecs_get_deal($deal_id);
+
+// Get the deals meta data
+$data = mspecs_get_mspecs_meta($deal);
+?>
+
+<?php // Output the selling text subject, using the safe array access method mspecs_get ?>
+<h1><?= esc_html(mspecs_get($data, 'sellingTexts.sellingTextSubject')) ?></h1>
+
+<?php // Output a formatted location, using the safe array access method mspecs_get ?>
+<h3><?= esc_html(implode(', ', [mspecs_get($data, 'location.streetAddress'), mspecs_get($data, 'location.city')])) ?></h3>
+
+<?php // Output the selling short text, using the safe array access method mspecs_get ?>
+<p><?= esc_html(mspecs_get($data, 'sellingTexts.sellingTextShort')) ?></p>
+
+<?php // Output the selling text, using the safe array access method mspecs_get ?>
+<p><?= esc_html(mspecs_get($data, 'sellingTexts.sellingText')) ?></p>
+
+<?php // Output images tags with descriptions, using the self hosted URL provided by mspecs_get_deal_images ?>
+<?= implode('', array_map(function($image){
+    return
+        '<p>'
+            .'<img src="'.esc_attr($image['viewUrl']).'" />'
+            .'<em>'.esc_html($image['title']).'</em>'
+        .'</p>';
+}, mspecs_get_deal_images($deal))) ?>
+
+<?php // Output file download links using the self hosted URL provided by mspecs_get_deal_files ?>
+<ul><?= implode('', array_map(function($file){
+    return '<li><a href="'.esc_url($file['url']).'" download>'.esc_html($file['title']).'</a></li>';
+}, mspecs_get_deal_files($deal))) ?></ul>
+
+<?php
+
+
+/*
+ * Ignore this function, it's just for the example
+ */
+function get_dummy_deal_id() {
+    $deals = mspecs_get_deals();
+    if(count($deals) > 0) {
+        return mspecs_get_deal_meta('mspecs_id', $deals[0]);
+    }
+    return null;
+}

--- a/public-api.php
+++ b/public-api.php
@@ -68,11 +68,11 @@ function mspecs_get_deal_files($deal = null){
     $files = mspecs_get_deal_meta('files', $deal);
     if(!$files) return [];
 
-    // Make sure the image urls are correct
+    // Make sure the file urls are correct
     foreach($files as $i => $file){
         $path = mspecs_get($file, 'path');
         if(!empty($path)){
-            $image['url'] = mspecs_file_dir_url() . '/' . $path;
+            $file['url'] = mspecs_file_dir_url() . '/' . $path;
         }
 
         $files[$i] = $file;


### PR DESCRIPTION
Added examples of using the MSPECS PHP API functions for listing and single detailed view.
These can be ran using for example a shortcode like this:

```php
add_shortcode('mspecs_test', function(){
  if(!defined('MSPECS_PLUGIN_DIR')) return 'MSPECS plugin not installed';
	
  ob_start();
	
  include(MSPECS_PLUGIN_DIR.'examples/listing.php');

  include(MSPECS_PLUGIN_DIR.'examples/single.php');

  return ob_get_clean();
});
```


Also included minor fix to `mspecs_get_deal_files` function