### PR TITLE
Allow overriding CPT names

### DIFF
--- a/inc/class.mspecs-admin.php
+++ b/inc/class.mspecs-admin.php
@@ -24,10 +24,10 @@ class Mspecs_Admin {
         if(
             $hook === 'settings_page_mspecs'
             || ($hook === 'post.php' && in_array(get_post_type(), array(
-                'mspecs_deal',
-                'mspecs_organization',
-                'mspecs_office',
-                'mspecs_user',
+                MSPECS_DEAL_CPT,
+                MSPECS_ORG_CPT,
+                MSPECS_OFFICE_CPT,
+                MSPECS_USER_CPT,
             )))
         ){
             // TODO: Minimize resources
@@ -53,7 +53,7 @@ class Mspecs_Admin {
                 'api_password' => '',
                 'api_access_token' => '',
                 'api_subscriber' => '',
-                'api_domain' => 'integration.mspecs.se', 
+                'api_domain' => 'integration.mspecs.se',
             )
         ));
 
@@ -80,7 +80,7 @@ class Mspecs_Admin {
     public static function api_settings_section_callback(){
         echo '<p>
             <h3>Instructions:</h3>
-            <a href="https://support.mspecs.se/sv-SE/support/solutions/articles/13000098836-wordpress-plugin-ny-"  target="_blank">READ ME</a> 
+            <a href="https://support.mspecs.se/sv-SE/support/solutions/articles/13000098836-wordpress-plugin-ny-"  target="_blank">READ ME</a>
             <ul>
                 <li>Basic auth is deprectade, use accessToken instead</li>
             </ul>
@@ -89,7 +89,7 @@ class Mspecs_Admin {
 
     private static function getAuthToggleSetting() {
         $settings = get_option('mspecs_settings');
-        return isset($settings['api_auth_toggle']) ? $settings['api_auth_toggle'] || 0 : 0; 
+        return isset($settings['api_auth_toggle']) ? $settings['api_auth_toggle'] || 0 : 0;
     }
 
     private static function getHideClassIfEq($val){
@@ -141,7 +141,7 @@ class Mspecs_Admin {
 
         if($static == false): ?>
             <input class="regular-text <?= $class ?>" type="<?= esc_attr($type) ?>" name="<?= esc_attr($full_key) ?>" value="<?= esc_attr( $value ) ?>">
-        <?php else: ?> 
+        <?php else: ?>
             <input class="regular-text <?= $class ?>" type="<?= esc_attr($type) ?>" value="<?= esc_attr( $value ) ?>" disabled>
         <?php endif;
     }
@@ -217,10 +217,10 @@ class Mspecs_Admin {
      */
     public static function add_meta_boxes(){
         add_meta_box( 'mspecs-post-meta', __('Mspecs data', 'mspecs'), array('Mspecs_Admin', 'display_post_meta_box'), array(
-            'mspecs_deal',
-            'mspecs_organization',
-            'mspecs_office',
-            'mspecs_user',
+            MSPECS_DEAL_CPT,
+            MSPECS_ORG_CPT,
+            MSPECS_OFFICE_CPT,
+            MSPECS_USER_CPT,
         ) );
     }
     public static function display_post_meta_box(){

--- a/inc/class.mspecs-store.php
+++ b/inc/class.mspecs-store.php
@@ -2,7 +2,7 @@
 
 class Mspecs_Store {
     public static function init(){
-        
+
     }
 
     /**
@@ -14,7 +14,7 @@ class Mspecs_Store {
     public static function get_organization(){
         $args = array(
             'orderby' => 'date',
-            'post_type' => 'mspecs_organization',
+            'post_type' => MSPECS_ORG_CPT,
         );
 
         $organizations = self::get_posts(apply_filters('mspecs_get_organization_args', $args));
@@ -51,21 +51,21 @@ class Mspecs_Store {
             return false;
         }
     }
-    
+
     /**
      * get_users
      *
      * @see get_posts
      *
      * @param array $args
-     * 
+     *
      * @return WP_Post[]|int[] Array of post objects or post IDs.
      */
     public static function get_users($args = array()){
         $args = wp_parse_args($args, array(
             'orderby' => 'title',
             'order' => 'ASC',
-            'post_type' => 'mspecs_user',
+            'post_type' => MSPECS_USER_CPT,
         ));
 
         $users = self::get_posts(apply_filters('mspecs_get_users_args', $args));
@@ -100,21 +100,21 @@ class Mspecs_Store {
             return false;
         }
     }
-    
+
     /**
      * get_offices
      *
      * @see get_posts
      *
      * @param array $args
-     * 
+     *
      * @return WP_Post[]|int[] Array of post objects or post IDs.
      */
     public static function get_offices($args = array()){
         $args = wp_parse_args($args, array(
             'orderby' => 'title',
             'order' => 'ASC',
-            'post_type' => 'mspecs_office',
+            'post_type' => MSPECS_OFFICE_CPT,
         ));
 
         $offices = self::get_posts(apply_filters('mspecs_get_offices_args', $args));
@@ -126,7 +126,7 @@ class Mspecs_Store {
      * get_deal
      *
      * @see mspecs_get_deal
-     * 
+     *
      */
     public static function get_deal($mspecs_id){
         if(empty($mspecs_id)){
@@ -149,18 +149,18 @@ class Mspecs_Store {
             return false;
         }
     }
-    
+
     /**
      * get_deals
      *
      * @see gmspecs_get_deals
-     * 
+     *
      */
     public static function get_deals($args = array()){
         $args = wp_parse_args($args, array(
             'orderby' => 'date',
             'order' => 'DESC',
-            'post_type' => 'mspecs_deal',
+            'post_type' => MSPECS_DEAL_CPT,
         ));
 
         $deals = self::get_posts(apply_filters('mspecs_get_deals_args', $args));
@@ -188,7 +188,7 @@ class Mspecs_Store {
     public static function get_unique_meta_values($meta_key){
         global $wpdb;
 
-        $sql = $wpdb->prepare("SELECT DISTINCT meta_value FROM $wpdb->postmeta pm, $wpdb->posts p WHERE meta_key = %s and pm.post_id=p.ID  and p.post_type='mspecs_deal'", $meta_key);
+        $sql = $wpdb->prepare("SELECT DISTINCT meta_value FROM $wpdb->postmeta pm, $wpdb->posts p WHERE meta_key = %s and pm.post_id=p.ID  and p.post_type='" . MSPECS_DEAL_CPT . "'", $meta_key);
         $values = $wpdb->get_results($sql, ARRAY_A);
 
         $values = array_map(function($value){

--- a/inc/class.mspecs-syncer.php
+++ b/inc/class.mspecs-syncer.php
@@ -2,7 +2,7 @@
 
 class Mspecs_Syncer extends Mspecs_WP_Background_Process{
     protected $action = 'mspecs_sync';
-    
+
     public $max_retries = 5;
     public $cron_interval = 5; // Minutes
 
@@ -113,7 +113,7 @@ class Mspecs_Syncer extends Mspecs_WP_Background_Process{
 
         // Set WP default fields
         $args = array(
-            'post_type' => 'mspecs_organization',
+            'post_type' => MSPECS_ORG_CPT,
             'post_title' => $get('name', ''),
             'post_status' => 'publish',
 
@@ -168,13 +168,13 @@ class Mspecs_Syncer extends Mspecs_WP_Background_Process{
 
         // Set WP default fields
         $args = array(
-            'post_type' => 'mspecs_office',
+            'post_type' => MSPECS_OFFICE_CPT,
             'post_title' => $get('name', ''),
             'post_status' => 'publish',
 
             // 'post_date' // TODO
         );
-        
+
         $old_deal = mspecs_get_office($mspecs_id);
         if($old_deal){
             $args['ID'] = $old_deal->ID;
@@ -223,13 +223,13 @@ class Mspecs_Syncer extends Mspecs_WP_Background_Process{
 
         // Set WP default fields
         $args = array(
-            'post_type' => 'mspecs_user',
+            'post_type' => MSPECS_USER_CPT,
             'post_title' => $get('firstName', '') . ' ' . $get('lastName', ''),
             'post_status' => 'publish',
 
             // 'post_date' // TODO
         );
-        
+
         $old_deal = mspecs_get_user($mspecs_id);
         if($old_deal){
             $args['ID'] = $old_deal->ID;
@@ -285,7 +285,7 @@ class Mspecs_Syncer extends Mspecs_WP_Background_Process{
 
         // Set WP default fields
         $args = array(
-            'post_type' => 'mspecs_deal',
+            'post_type' => MSPECS_DEAL_CPT,
             'post_title' => $get('shortId', ''),
             'post_content' => $get('sellingTexts.sellingText', ''),
             'post_excerpt' => $get('sellingTexts.sellingTextShort', ''),
@@ -293,7 +293,7 @@ class Mspecs_Syncer extends Mspecs_WP_Background_Process{
 
             // 'post_date' // TODO
         );
-        
+
         $old_deal = mspecs_get_deal($mspecs_id);
         if($old_deal){
             $args['ID'] = $old_deal->ID;
@@ -473,7 +473,7 @@ class Mspecs_Syncer extends Mspecs_WP_Background_Process{
         $dir = dirname($file_path);
 
         // Save file, based on wp_upload_bits
-        
+
         wp_mkdir_p($dir);
 
         $ifp = @fopen( $file_path, 'wb' );
@@ -649,7 +649,7 @@ class Mspecs_Syncer extends Mspecs_WP_Background_Process{
         $api_client = Mspecs::get_api_client();
         $response = $api_client->generate_webhook_secret();
         $secret = isset($response['secret']) ? $response['secret'] : false;
-        
+
         if($secret){
             mspecs_update_setting('api_secret', $secret);
         }

--- a/inc/class.mspecs.php
+++ b/inc/class.mspecs.php
@@ -19,7 +19,7 @@ class Mspecs {
     }
 
     public static function register_post_types(){
-        register_post_type('mspecs_deal', apply_filters('mspecs_deal_post_type', array(
+        register_post_type(MSPECS_DEAL_CPT, apply_filters('mspecs_deal_post_type', array(
             'labels' => array(
                 'name' => __('Deals - Mspecs', 'mspecs'),
                 'singular_name' => __('Deal', 'mspecs'),
@@ -50,10 +50,10 @@ class Mspecs {
             'show_ui' => true,
             'menu_icon' => 'dashicons-admin-home',
             'capability_type' => 'post', // TODO: Change?
-            'supports' => array('title', 'editor'),       
+            'supports' => array('title', 'editor'),
         )));
 
-        register_post_type('mspecs_office', apply_filters('mspecs_office_post_type', array(
+        register_post_type(MSPECS_OFFICE_CPT, apply_filters('mspecs_office_post_type', array(
             'labels' => array(
                 'name' => __('Offices - Mspecs', 'mspecs'),
                 'singular_name' => __('Office', 'mspecs'),
@@ -83,11 +83,11 @@ class Mspecs {
             'hierarchical' => false,
             'show_ui' => true, // TODO: Switch off
             'menu_icon' => 'dashicons-location',
-            'capability_type' => 'post', // TODO: Change?  
-            'supports' => array('title'),          
+            'capability_type' => 'post', // TODO: Change?
+            'supports' => array('title'),
         )));
 
-        register_post_type('mspecs_user', apply_filters('mspecs_user_post_type', array(
+        register_post_type(MSPECS_USER_CPT, apply_filters('mspecs_user_post_type', array(
             'labels' => array(
                 'name' => __('Users - Mspecs', 'mspecs'),
                 'singular_name' => __('User', 'mspecs'),
@@ -117,11 +117,11 @@ class Mspecs {
             'hierarchical' => false,
             'show_ui' => true, // TODO: Switch off
             'menu_icon' => 'dashicons-id-alt',
-            'capability_type' => 'post', // TODO: Change?    
-            'supports' => array('title'),        
+            'capability_type' => 'post', // TODO: Change?
+            'supports' => array('title'),
         )));
 
-        register_post_type('mspecs_organization', apply_filters('mspecs_organization_post_type', array(
+        register_post_type(MSPECS_ORG_CPT, apply_filters('mspecs_organization_post_type', array(
             'labels' => array(
                 'name' => __('Organizations - Mspecs', 'mspecs'),
                 'singular_name' => __('Organization', 'mspecs'),
@@ -152,7 +152,7 @@ class Mspecs {
             'show_ui' => true, // TODO: Switch off
             'menu_icon' => 'dashicons-store',
             'capability_type' => 'post', // TODO: Change?
-            'supports' => array('title'),         
+            'supports' => array('title'),
         )));
     }
 

--- a/mspecs.php
+++ b/mspecs.php
@@ -2,10 +2,23 @@
 /*
 Plugin Name: Mspecs Mäklarsystem - API
 Plugin URI: https://www.mspecs.se/
-Description: 
+Description:
 Author: Mspecs
 Version: 1.0.0
 */
+
+if (!defined('MSPECS_DEAL_CPT')) {
+	define('MSPECS_DEAL_CPT', 'mspecs_deal');
+}
+if (!defined('MSPECS_ORG_CPT')) {
+	define('MSPECS_ORG_CPT', 'mspecs_organization');
+}
+if (!defined('MSPECS_USER_CPT')) {
+	define('MSPECS_USER_CPT', 'mspecs_user');
+}
+if (!defined('MSPECS_OFFICE_CPT')) {
+	define('MSPECS_OFFICE_CPT', 'mspecs_office');
+}
 
 define( 'MSPECS_PLUGIN_FILE', __FILE__ );
 define( 'MSPECS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/public-api.php
+++ b/public-api.php
@@ -117,9 +117,9 @@ function mspecs_get_viewings($deal = null){
 /**
  * Returns the current global $post object if it is a Mspecs Deal
  * If the $deal parameter is passed, it will instead return the WP_Post object if it is an Mspecs Deal or deal ID
- *  
+ *
  * @param  WP_Post|string|null $deal
- * 
+ *
  * @return WP_Post|null
  */
 function mspecs_get_the_deal($deal = null){
@@ -139,7 +139,7 @@ function mspecs_get_the_deal($deal = null){
  * @return bool
  */
 function mspecs_is_deal($deal){
-    return $deal && isset($deal->post_type) && $deal->post_type === 'mspecs_deal';
+    return $deal && isset($deal->post_type) && $deal->post_type === MSPECS_DEAL_CPT;
 }
 
 /*
@@ -209,7 +209,7 @@ function mspecs_get_deal($mspecs_id){
         return mspecs_is_deal($mspecs_id) ? $mspecs_id : false;
     }
 
-    return Mspecs_Store::get_deal($mspecs_id); 
+    return Mspecs_Store::get_deal($mspecs_id);
 }
 
 /**
@@ -218,7 +218,7 @@ function mspecs_get_deal($mspecs_id){
  * @see get_posts
  *
  * @param array $args
- * 
+ *
  * @return WP_Post[]|int[] Array of post objects or post IDs.
  */
 function mspecs_get_deals($args = array()){
@@ -229,7 +229,7 @@ function mspecs_get_deals($args = array()){
  *  Post data functions
  */
 
- 
+
 /**
  * Add a new prospective buyer to a deal. An error will be returned if the buyer is already added.
  *
@@ -331,7 +331,7 @@ function mspecs_get_organization(){
  * @return WP_Post|false
  */
 function mspecs_get_office($mspecs_id){
-    return Mspecs_Store::get_office($mspecs_id); 
+    return Mspecs_Store::get_office($mspecs_id);
 }
 
 /**
@@ -340,7 +340,7 @@ function mspecs_get_office($mspecs_id){
  * @see get_posts
  *
  * @param array $args
- * 
+ *
  * @return WP_Post[]|int[] Array of post objects or post IDs.
  */
 function mspecs_get_offices($args = array()){
@@ -354,7 +354,7 @@ function mspecs_get_offices($args = array()){
  * @return WP_Post|false
  */
 function mspecs_get_user($mspecs_id){
-    return Mspecs_Store::get_user($mspecs_id); 
+    return Mspecs_Store::get_user($mspecs_id);
 }
 
 /**
@@ -363,7 +363,7 @@ function mspecs_get_user($mspecs_id){
  * @see get_posts
  *
  * @param array $args
- * 
+ *
  * @return WP_Post[]|int[] Array of post objects or post IDs.
  */
 function mspecs_get_users($args = array()){


### PR DESCRIPTION
This PR stores all custom post type names as constants (using `define()`), allowing users of the plug-in to override the post-type names.

I have tested it locally both with the default names, and using a custom name for `MSPECS_DEAL_CPT` and both work fine for me.

(There appears to have been some whitespace trimmed as well, my editor does that by default on save).